### PR TITLE
feat: Minecraft UUID 検知と NameMC URL 投稿機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Discord Developer Portal で取得したボットの認証トークン
+DISCORD_TOKEN=
+
+# リアクションロールで付与するロールの ID（整数）
+DEFAULT_ROLE_ID=
+
+# リアクションロールのトリガーとなるメッセージの ID（整数）
+TARGET_MESSAGE_ID=
+
+# Minecraft UUID 検知時に NameMC URL を投稿するチャンネルの ID（整数）
+NAMEMC_CHANNEL_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,14 @@ python3 app/script/main.py
 
 ## 環境変数
 
-`docker-compose.yaml` の `environment:` に設定する：
+`.env` ファイルに設定する（`.env.example` をコピーして使用）：
 
 | 変数名 | 説明 |
 |---|---|
 | `DISCORD_TOKEN` | Discord Developer Portal で取得したボットの認証トークン |
 | `DEFAULT_ROLE_ID` | 対象メッセージにリアクションしたユーザーへ付与するロールの ID（整数） |
 | `TARGET_MESSAGE_ID` | リアクションロール付与のトリガーとなるメッセージの ID（整数） |
+| `NAMEMC_CHANNEL_ID` | Minecraft UUID 検知時に NameMC URL を投稿するチャンネルの ID（整数） |
 
 ## アーキテクチャ
 
@@ -47,6 +48,7 @@ python3 app/script/main.py
 2. **`/neo_omikuji`** — `config/neo_omikuji.txt` から詳細なおみくじを引く（フォーマット: `運勢, 説明`）
 3. **リアクションロール** — `on_raw_reaction_add` で `TARGET_MESSAGE_ID` へのリアクション時に `DEFAULT_ROLE_ID` を付与する
 4. **メンション返答** — `on_message` でボットがメンションされた際に `config/mention.txt` からランダムな一文を送信する
+5. **Minecraft UUID 検知** — `on_message` で `Minecraft UUID: <uuid>` パターンを検知し、`https://ja.namemc.com/search?q=<uuid>` を `NAMEMC_CHANNEL_ID` のチャンネルへ投稿する
 
 **設定ファイル**（`app/script/config/`）は改行区切りのプレーンテキスト。起動時に `load_config()` で一度だけ読み込まれる。
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |---|---|
 | リアクションロール付与 | 特定のメッセージへのリアクション時に、指定したロールを付与します |
 | メンション返答 | ボットがメンションされた際にランダムな返答を送信します |
+| Minecraft UUID 検知 | 他のボットが送信するアカウント連携メッセージから Minecraft UUID を抽出し、指定チャンネルに ja.namemc.com の検索 URL を投稿します |
 
 ## Dockerコンテナで実行
 1. BOTのトークンを取得 ※以下BOT作成手順参照
@@ -24,6 +25,12 @@
     DISCORD_TOKEN=取得したトークン
     DEFAULT_ROLE_ID=付与するロールのID
     TARGET_MESSAGE_ID=リアクション対象のメッセージID
+    NAMEMC_CHANNEL_ID=NameMC URLを投稿するチャンネルのID
+    ```
+
+    `.env.example` をコピーして使うと便利です：
+    ```bash
+    cp .env.example .env
     ```
 
 4. `docker compose up -d`

--- a/app/script/main.py
+++ b/app/script/main.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import random
 from pathlib import Path
@@ -18,8 +19,15 @@ def get_env(key: str, cast=str):
 DISCORD_TOKEN = get_env('DISCORD_TOKEN')
 DEFAULT_ROLE_ID = get_env('DEFAULT_ROLE_ID', int)
 TARGET_MESSAGE_ID = get_env('TARGET_MESSAGE_ID', int)
+NAMEMC_CHANNEL_ID = get_env('NAMEMC_CHANNEL_ID', int)
 
 BASE_DIR = Path(__file__).parent
+
+# Minecraft UUID 検知パターン
+UUID_PATTERN = re.compile(
+    r'Minecraft UUID: ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+    re.IGNORECASE
+)
 
 # コンフィグファイルの読み込み
 def load_config(path: Path) -> list[str]:
@@ -69,6 +77,15 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent) -> None:
 async def on_message(message: discord.Message) -> None:
     if message.author == bot.user:
         return
+
+    # Minecraft UUID 検知処理
+    match = UUID_PATTERN.search(message.content)
+    if match:
+        uuid = match.group(1)
+        url = f'https://ja.namemc.com/search?q={uuid}'
+        channel = bot.get_channel(NAMEMC_CHANNEL_ID)
+        if channel:
+            await channel.send(url)
 
     if bot.user in message.mentions:
         await message.channel.send(random.choice(mention_response))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,5 @@ services:
     build: ./app
     container_name: ryo-bot
     restart: always
-    environment:
-      DISCORD_TOKEN: ${DISCORD_TOKEN}
-      DEFAULT_ROLE_ID: ${DEFAULT_ROLE_ID}
-      TARGET_MESSAGE_ID: ${TARGET_MESSAGE_ID}
+    env_file:
+      - .env

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,16 +1,8 @@
-
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ryo-discord-bot
-  labels:
-    name: ryo-discord-bot
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ryo-discord-bot
-  namespace: ryo-discord-bot
+  namespace: ryo-server
 spec:
   selector:
     matchLabels:
@@ -25,9 +17,12 @@ spec:
       - name: ryo-discord-bot
         image: ghcr.io/ryo-icy/ryo-discord-bot:latest
         env:
+            # Tokenはハードコーディングしないほうがいいよ(あくまでサンプル)
             - name: DISCORD_TOKEN
-              value: ${DISCORD_TOKEN}
+              value: ""
             - name: DEFAULT_ROLE_ID
-              value: ${DEFAULT_ROLE_ID}
+              value: ""
             - name: TARGET_MESSAGE_ID
-              value: ${TARGET_MESSAGE_ID}
+              value: ""
+            - name: NAMEMC_CHANNEL_ID
+              value: ""


### PR DESCRIPTION
- 他ボットのアカウント連携メッセージから UUID を正規表現で抽出し ja.namemc.com の検索 URL を指定チャンネルへ自動投稿
- 環境変数 NAMEMC_CHANNEL_ID を追加
- docker-compose.yaml の環境変数を .env ファイルに移行
- .env.example をテンプレートとして追加
- kubernetes.yaml を本番スタイルに合わせて更新
- README.md・CLAUDE.md を最新内容に反映