### PR TITLE
chore: Renovate Bot を導入し discord.py のバージョンを固定

### DIFF
--- a/app/script/requirements.txt
+++ b/app/script/requirements.txt
@@ -1,1 +1,1 @@
-discord.py
+discord.py==2.7.1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["every weekend"],
+  "reviewers": ["ryo-icy"],
+  "enabledManagers": ["github-actions", "dockerfile", "pip_requirements"],
+  "packageRules": [
+    {
+      "matchManagers": ["pip_requirements"],
+      "fileMatch": ["^app/script/requirements\\.txt$"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
- renovate.json を追加（GitHub Actions / Dockerfile / pip_requirements を管理対象に設定）
- discord.py のバージョンを未固定から 2.7.1 に固定