### PR TITLE
fix: packageRules の不正な fileMatch 設定を削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
   "enabledManagers": ["github-actions", "dockerfile", "pip_requirements"],
   "packageRules": [
     {
-      "matchManagers": ["pip_requirements"],
-      "fileMatch": ["^app/script/requirements\\.txt$"]
-    },
-    {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true


### PR DESCRIPTION
pip_requirements のデフォルトパターンが requirements.txt に既にマッチするため不要