### PR TITLE
docs: GHCR パッケージの Actions アクセス許可に関する注意点を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ src/ryo_discord_bot/
 
 `main` ブランチへのプッシュ（`src/**`・`Dockerfile`・`pyproject.toml`・`uv.lock` 変更時）で `.github/workflows/docker.yml` が起動し、Docker イメージをビルドして `ghcr.io/ryo-icy/ryo-discord-bot:latest` へプッシュする。認証は `GITHUB_TOKEN`（`permissions: packages: write`）。
 
+> [!NOTE]
+> GHCR パッケージ `ryo-discord-bot` の push には、パッケージ側の設定（ https://github.com/users/ryo-icy/packages/container/ryo-discord-bot/settings の「Manage Actions access」）でこのリポジトリに **Write** ロールが付与されている必要がある。以前 `CR_PAT`（個人 PAT）で push していたため未リンクだった際に `permission_denied: write_package` で失敗した。リポジトリの Settings > Actions > General > Workflow permissions を `Read and write` にするだけでは不十分で、パッケージ側の許可が別途必要。
+
 ## 新機能の追加
 
 1. `src/ryo_discord_bot/cogs/` に `commands.Cog` のサブクラスを作成する


### PR DESCRIPTION
## 概要

先日の PR #18 のマージ後、Actions（Build and Publish Docker）が `permission_denied: write_package` で失敗した。原因と対処法を AGENTS.md に記録しておく。

## 変更内容

- GHCR パッケージ側の「Manage Actions access」でリポジトリに Write ロールを付与する必要がある旨を AGENTS.md の CI/CD セクションに追記
- あわせて、リポジトリの Workflow permissions を Read and write にするだけでは不十分である点も明記

## 確認事項

- [x] 実際に Actions（run #29096632049）が成功することを確認済み

🤖 Generated by Claude Fable 5