### PR TITLE
feat: おみくじ結果を記録し統計表示する /omikuji_status を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 *.pyc
 .ruff_cache/
+data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ uv run ruff format .    # フォーマット
 | `DEFAULT_ROLE_ID` | 対象メッセージにリアクションしたユーザーへ付与するロールの ID（整数） |
 | `TARGET_MESSAGE_ID` | リアクションロール付与のトリガーとなるメッセージの ID（整数） |
 | `NAMEMC_CHANNEL_ID` | Minecraft UUID 検知時に NameMC URL を投稿するチャンネルの ID（整数） |
+| `OMIKUJI_DB_PATH` | おみくじ結果を記録する SQLite DB のパス（任意・既定 `data/omikuji.db`） |
 
 ## アーキテクチャ
 
@@ -57,19 +58,21 @@ src/ryo_discord_bot/
 ├── __main__.py        # エントリポイント。Bot クラス定義・Cog 登録・tree.sync（setup_hook で1回のみ）
 ├── settings.py        # 環境変数の読み込み・検証（frozen dataclass）
 ├── config_loader.py   # config/ 内テキストファイルの読み込み（モジュール位置基準の絶対パス解決）
+├── storage.py         # おみくじ結果の SQLite 記録・集計（OmikujiStore、threading.Lock で直列化）
 ├── cogs/
-│   ├── omikuji.py         # /omikuji（Range[int, 1, 3]）と /neo_omikuji
+│   ├── omikuji.py         # /omikuji（Range[int, 1, 3]）・/neo_omikuji・/omikuji_status
 │   ├── reaction_role.py   # TARGET_MESSAGE_ID へのリアクションで DEFAULT_ROLE_ID を付与
 │   └── message_watch.py   # Minecraft UUID 検知（NameMC URL 投稿）とメンション返答
 └── config/            # 改行区切りのプレーンテキスト（omikuji / neo_omikuji / mention）
 ```
 
 **機能一覧：**
-1. **`/omikuji [1~3]`** — `config/omikuji.txt` からランダムに N 回おみくじを引く
-2. **`/neo_omikuji`** — `config/neo_omikuji.txt` から詳細なおみくじを引く（フォーマット: `運勢, 説明`）
-3. **リアクションロール** — `on_raw_reaction_add` で `TARGET_MESSAGE_ID` へのリアクション時に `DEFAULT_ROLE_ID` を付与する
-4. **メンション返答** — `on_message` でボットがメンションされた際に `config/mention.txt` からランダムな一文を送信する
-5. **Minecraft UUID 検知** — `on_message` で `Minecraft UUID: <uuid>` パターンを検知し、`https://ja.namemc.com/search?q=<uuid>` を `NAMEMC_CHANNEL_ID` のチャンネルへ投稿する
+1. **`/omikuji [1~3]`** — `config/omikuji.txt` からランダムに N 回おみくじを引く（結果は SQLite に記録）
+2. **`/neo_omikuji`** — `config/neo_omikuji.txt` から詳細なおみくじを引く（フォーマット: `運勢, 説明`。運勢部分を記録）
+3. **`/omikuji_status [個人/全体]`** — 記録したおみくじ結果の統計（実行回数・結果内訳・直近10件など）を表示する
+4. **リアクションロール** — `on_raw_reaction_add` で `TARGET_MESSAGE_ID` へのリアクション時に `DEFAULT_ROLE_ID` を付与する
+5. **メンション返答** — `on_message` でボットがメンションされた際に `config/mention.txt` からランダムな一文を送信する
+6. **Minecraft UUID 検知** — `on_message` で `Minecraft UUID: <uuid>` パターンを検知し、`https://ja.namemc.com/search?q=<uuid>` を `NAMEMC_CHANNEL_ID` のチャンネルへ投稿する
 
 設定ファイルは各 Cog の `__init__` で `load_config()` により一度だけ読み込まれる。
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN uv sync --frozen --no-dev
 
 ENV PATH="/opt/venv/bin:${PATH}"
 
-# 非 root ユーザーで実行
-RUN useradd -m -u 1001 bot
+# 非 root ユーザーで実行（おみくじ記録用の data ディレクトリを事前に作成し所有権を渡す）
+RUN useradd -m -u 1001 bot && mkdir -p /app/data && chown bot:bot /app/data
 USER bot
 
 CMD ["python", "-m", "ryo_discord_bot"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,3 +9,8 @@ services:
       - .env
     environment:
       TZ: Asia/Tokyo
+    volumes:
+      - omikuji-data:/app/data
+
+volumes:
+  omikuji-data:

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,3 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ryo-discord-bot-data
+  namespace: ryo-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,6 +25,9 @@ spec:
       labels:
         app: ryo-discord-bot
     spec:
+      # PVC マウント先（/app/data）を非 root ユーザー（uid 1001）が書き込めるようにする
+      securityContext:
+        fsGroup: 1001
       containers:
       - name: ryo-discord-bot
         image: ghcr.io/ryo-icy/ryo-discord-bot:latest
@@ -21,3 +36,10 @@ spec:
         envFrom:
           - secretRef:
               name: ryo-discord-bot-env
+        volumeMounts:
+          - name: omikuji-data
+            mountPath: /app/data
+      volumes:
+        - name: omikuji-data
+          persistentVolumeClaim:
+            claimName: ryo-discord-bot-data

--- a/src/ryo_discord_bot/__main__.py
+++ b/src/ryo_discord_bot/__main__.py
@@ -22,7 +22,7 @@ class RyoDiscordBot(commands.Bot):
 
     # setup_hook は起動時に一度だけ呼ばれるため、再接続のたびに sync されない
     async def setup_hook(self) -> None:
-        await self.add_cog(OmikujiCog(self))
+        await self.add_cog(OmikujiCog(self, self.settings))
         await self.add_cog(ReactionRoleCog(self, self.settings))
         await self.add_cog(MessageWatchCog(self, self.settings))
         await self.tree.sync()

--- a/src/ryo_discord_bot/cogs/omikuji.py
+++ b/src/ryo_discord_bot/cogs/omikuji.py
@@ -1,33 +1,134 @@
+import asyncio
 import random
+from typing import Literal
 
 import discord
 from discord import app_commands
 from discord.ext import commands
 
 from ryo_discord_bot.config_loader import load_config
+from ryo_discord_bot.settings import Settings
+from ryo_discord_bot.storage import GlobalStats, OmikujiStore, PersonalStats, ResultCount
 
 
-# おみくじ機能（/omikuji, /neo_omikuji）
+# おみくじ機能（/omikuji, /neo_omikuji, /omikuji_status）
 class OmikujiCog(commands.Cog):
-    def __init__(self, bot: commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot, settings: Settings) -> None:
         self.bot = bot
         self.omikuji_list = load_config("omikuji.txt")
         self.neo_omikuji_list = load_config("neo_omikuji.txt")
+        self.store = OmikujiStore(settings.omikuji_db_path)
 
-    # おみくじメッセージを送信する処理
+    def cog_unload(self) -> None:
+        self.store.close()
+
+    # おみくじメッセージを送信し、結果を記録する処理
     async def _send_omikuji(
-        self, interaction: discord.Interaction, messages: list[str], count: int = 1
+        self,
+        interaction: discord.Interaction,
+        messages: list[str],
+        *,
+        command: str,
+        count: int = 1,
     ) -> None:
-        result = "\n".join(random.choices(messages, k=count))
-        await interaction.response.send_message(result)
+        drawn = random.choices(messages, k=count)
+        await interaction.response.send_message("\n".join(drawn))
+
+        # neo_omikuji は「運勢, 説明」形式なので、記録は運勢部分のみにする
+        results = [line.split(",", 1)[0].strip() for line in drawn]
+        await asyncio.to_thread(
+            self.store.record, interaction.guild_id, interaction.user.id, command, results
+        )
 
     @app_commands.command(name="omikuji", description="おみくじを引くことができます")
     @app_commands.describe(arg="回数（1〜3）")
     async def omikuji(
         self, interaction: discord.Interaction, arg: app_commands.Range[int, 1, 3] = 1
     ) -> None:
-        await self._send_omikuji(interaction, self.omikuji_list, arg)
+        await self._send_omikuji(interaction, self.omikuji_list, command="omikuji", count=arg)
 
     @app_commands.command(name="neo_omikuji", description="すごいおみくじを引くことができます")
     async def neo_omikuji(self, interaction: discord.Interaction) -> None:
-        await self._send_omikuji(interaction, self.neo_omikuji_list)
+        await self._send_omikuji(interaction, self.neo_omikuji_list, command="neo_omikuji")
+
+    @app_commands.command(name="omikuji_status", description="おみくじの結果を確認できます")
+    @app_commands.describe(scope="表示範囲（個人 / 全体）")
+    async def omikuji_status(
+        self, interaction: discord.Interaction, scope: Literal["個人", "全体"] = "個人"
+    ) -> None:
+        if scope == "個人":
+            stats = await asyncio.to_thread(
+                self.store.personal_stats, interaction.guild_id, interaction.user.id
+            )
+            embed = self._build_personal_embed(interaction.user, stats)
+        else:
+            stats = await asyncio.to_thread(self.store.global_stats, interaction.guild_id)
+            embed = self._build_global_embed(stats)
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    # 個人統計用の Embed を組み立てる
+    def _build_personal_embed(
+        self, user: discord.User | discord.Member, stats: PersonalStats
+    ) -> discord.Embed:
+        embed = discord.Embed(title=f"{user.display_name} さんのおみくじ結果", color=0xF4C542)
+
+        if not stats["command_counts"]:
+            embed.description = "まだおみくじを引いた記録がありません。"
+            return embed
+
+        embed.add_field(
+            name="実行回数",
+            value="\n".join(f"{c['command']}: {c['count']}回" for c in stats["command_counts"]),
+            inline=False,
+        )
+        embed.add_field(
+            name="出た結果の回数",
+            value=_format_result_counts(stats["result_counts"]),
+            inline=False,
+        )
+        embed.add_field(
+            name="直近10件",
+            value="\n".join(
+                f"[{d['created_at']}] {d['command']}: {d['result']}" for d in stats["recent_draws"]
+            ),
+            inline=False,
+        )
+        return embed
+
+    # 全体統計用の Embed を組み立てる
+    def _build_global_embed(self, stats: GlobalStats) -> discord.Embed:
+        embed = discord.Embed(title="サーバ全体のおみくじ結果", color=0xF4C542)
+
+        if not stats["command_counts"]:
+            embed.description = "まだおみくじを引いた記録がありません。"
+            return embed
+
+        embed.add_field(
+            name="実行回数",
+            value="\n".join(f"{c['command']}: {c['count']}回" for c in stats["command_counts"]),
+            inline=False,
+        )
+        embed.add_field(
+            name="個人別実行回数",
+            value="\n".join(f"<@{u['user_id']}>: {u['count']}回" for u in stats["user_counts"]),
+            inline=False,
+        )
+        embed.add_field(
+            name="出た結果の累計回数",
+            value=_format_result_counts(stats["result_counts"]),
+            inline=False,
+        )
+        return embed
+
+
+# コマンド別に「結果: 回数」を整形する（Embed のフィールド用）
+def _format_result_counts(result_counts: list[ResultCount]) -> str:
+    lines: list[str] = []
+    current_command: str | None = None
+    for row in result_counts:
+        if row["command"] != current_command:
+            current_command = row["command"]
+            lines.append(f"**{current_command}**")
+        lines.append(f"　{row['result']}: {row['count']}回")
+    return "\n".join(lines)

--- a/src/ryo_discord_bot/settings.py
+++ b/src/ryo_discord_bot/settings.py
@@ -22,6 +22,7 @@ class Settings:
     default_role_id: int
     target_message_id: int
     namemc_channel_id: int
+    omikuji_db_path: str
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -30,4 +31,5 @@ class Settings:
             default_role_id=_get_env("DEFAULT_ROLE_ID", int),
             target_message_id=_get_env("TARGET_MESSAGE_ID", int),
             namemc_channel_id=_get_env("NAMEMC_CHANNEL_ID", int),
+            omikuji_db_path=os.getenv("OMIKUJI_DB_PATH", "data/omikuji.db"),
         )

--- a/src/ryo_discord_bot/storage.py
+++ b/src/ryo_discord_bot/storage.py
@@ -1,0 +1,155 @@
+import sqlite3
+import threading
+from pathlib import Path
+from typing import TypedDict
+
+
+# おみくじの実行結果を記録・集計する SQLite ストア
+class CommandCount(TypedDict):
+    command: str
+    count: int
+
+
+class ResultCount(TypedDict):
+    command: str
+    result: str
+    count: int
+
+
+class RecentDraw(TypedDict):
+    command: str
+    result: str
+    created_at: str
+
+
+class UserCount(TypedDict):
+    user_id: int
+    count: int
+
+
+class PersonalStats(TypedDict):
+    command_counts: list[CommandCount]
+    result_counts: list[ResultCount]
+    recent_draws: list[RecentDraw]
+
+
+class GlobalStats(TypedDict):
+    command_counts: list[CommandCount]
+    user_counts: list[UserCount]
+    result_counts: list[ResultCount]
+
+
+class OmikujiStore:
+    def __init__(self, db_path: str) -> None:
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        # asyncio.to_thread で呼び出されるため複数スレッドから同一接続を共有する。
+        # sqlite3 は接続の共有時、書き込み操作の直列化を呼び出し側に要求するため
+        # threading.Lock で全操作を直列化する。
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        with self._lock:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS omikuji_draws (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id   INTEGER,
+                    user_id    INTEGER NOT NULL,
+                    command    TEXT    NOT NULL,
+                    result     TEXT    NOT NULL,
+                    created_at TEXT    NOT NULL DEFAULT (datetime('now', 'localtime'))
+                )
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_draws_guild ON omikuji_draws(guild_id)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_draws_user ON omikuji_draws(guild_id, user_id)"
+            )
+            self._conn.commit()
+
+    # おみくじの実行結果を記録する（1コマンド実行で複数件になる場合がある）
+    def record(self, guild_id: int | None, user_id: int, command: str, results: list[str]) -> None:
+        with self._lock:
+            self._conn.executemany(
+                "INSERT INTO omikuji_draws (guild_id, user_id, command, result) "
+                "VALUES (?, ?, ?, ?)",
+                [(guild_id, user_id, command, result) for result in results],
+            )
+            self._conn.commit()
+
+    # 個人の統計（コマンド別実行回数・結果内訳・直近10件）を取得する
+    def personal_stats(self, guild_id: int | None, user_id: int) -> PersonalStats:
+        with self._lock:
+            guild_clause = "guild_id IS ?" if guild_id is None else "guild_id = ?"
+
+            command_counts = self._conn.execute(
+                f"SELECT command, COUNT(*) AS count FROM omikuji_draws "
+                f"WHERE {guild_clause} AND user_id = ? "
+                f"GROUP BY command ORDER BY command",
+                (guild_id, user_id),
+            ).fetchall()
+
+            result_counts = self._conn.execute(
+                f"SELECT command, result, COUNT(*) AS count FROM omikuji_draws "
+                f"WHERE {guild_clause} AND user_id = ? "
+                f"GROUP BY command, result ORDER BY command, count DESC",
+                (guild_id, user_id),
+            ).fetchall()
+
+            recent_draws = self._conn.execute(
+                f"SELECT command, result, created_at FROM omikuji_draws "
+                f"WHERE {guild_clause} AND user_id = ? "
+                f"ORDER BY id DESC LIMIT 10",
+                (guild_id, user_id),
+            ).fetchall()
+
+            return {
+                "command_counts": [{"command": row[0], "count": row[1]} for row in command_counts],
+                "result_counts": [
+                    {"command": row[0], "result": row[1], "count": row[2]} for row in result_counts
+                ],
+                "recent_draws": [
+                    {"command": row[0], "result": row[1], "created_at": row[2]}
+                    for row in recent_draws
+                ],
+            }
+
+    # サーバ全体の統計（コマンド別総回数・個人別実行回数・結果累計回数）を取得する
+    def global_stats(self, guild_id: int | None) -> GlobalStats:
+        with self._lock:
+            guild_clause = "guild_id IS ?" if guild_id is None else "guild_id = ?"
+
+            command_counts = self._conn.execute(
+                f"SELECT command, COUNT(*) AS count FROM omikuji_draws "
+                f"WHERE {guild_clause} "
+                f"GROUP BY command ORDER BY command",
+                (guild_id,),
+            ).fetchall()
+
+            user_counts = self._conn.execute(
+                f"SELECT user_id, COUNT(*) AS count FROM omikuji_draws "
+                f"WHERE {guild_clause} "
+                f"GROUP BY user_id ORDER BY count DESC LIMIT 10",
+                (guild_id,),
+            ).fetchall()
+
+            result_counts = self._conn.execute(
+                f"SELECT command, result, COUNT(*) AS count FROM omikuji_draws "
+                f"WHERE {guild_clause} "
+                f"GROUP BY command, result ORDER BY command, count DESC",
+                (guild_id,),
+            ).fetchall()
+
+            return {
+                "command_counts": [{"command": row[0], "count": row[1]} for row in command_counts],
+                "user_counts": [{"user_id": row[0], "count": row[1]} for row in user_counts],
+                "result_counts": [
+                    {"command": row[0], "result": row[1], "count": row[2]} for row in result_counts
+                ],
+            }
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()


### PR DESCRIPTION
## 概要

Closes #17

`/omikuji`・`/neo_omikuji` の実行結果を SQLite に記録し、`/omikuji_status` で個人/全体の統計を確認できるようにする。

## 変更内容

- SQLite（標準ライブラリ）でおみくじ結果を記録・集計する `OmikujiStore` を新規実装（`storage.py`。`threading.Lock` で書き込みを直列化し、JST で保存）
- `/omikuji_status`（`scope: 個人 / 全体`）を追加し、実行回数・結果内訳・直近10件を Embed で表示
- `OMIKUJI_DB_PATH` 環境変数で DB パスを設定可能に（既定 `data/omikuji.db`）
- Docker（named volume）・Kubernetes（PVC + `fsGroup: 1001`）に永続化ボリュームを追加

## 確認事項

- [ ] `.env` を用意しローカルで起動し、`/omikuji`・`/neo_omikuji`・`/omikuji_status`（個人/全体）が正しく動作すること
- [ ] Docker で `docker compose down && up -d` 後も記録が保持されること（named volume の永続化）
- [ ] Kubernetes デプロイ後、PVC マウントに bot ユーザー（uid 1001）が書き込めること

🤖 Generated by Claude